### PR TITLE
Clean up code a lot and fix the section selection radio input

### DIFF
--- a/src/components/Calender.svelte
+++ b/src/components/Calender.svelte
@@ -147,7 +147,7 @@
 		{#if activePlan}
 			{#each activePlan.courses as course, i}
 				{#each course.sections as section}
-					{#if section.selected}
+					{#if section.SECTION === course.selectedSection}
 						{#each section.TIMES as meeting}
 							<CourseSection
 								top={hourHeight *

--- a/src/components/Tabs/SearchTab.svelte
+++ b/src/components/Tabs/SearchTab.svelte
@@ -13,6 +13,7 @@
 	interface Course {
 		_id: string;
 		sections: { section: string; selected: boolean }[];
+		selectedSection: string;
 	}
 	interface Plan {
 		active: boolean;
@@ -46,42 +47,7 @@
 				});
 			});
 	}
-	function selectSection(course: string, section: string) {
-		planStore.update((plans) => {
-			//mark the section as selected and unselect all other sections in that course
-			let activePlan = plans.find((p: { active: boolean }) => p.active);
-			if (!activePlan) {
-				plans.push({
-					active: true,
-					courses: [
-						{
-							course: course,
-							sections: [{ section: section, selected: true }],
-							id: uuidv4(),
-							name: `Plan ${plans.length + 1}`
-						}
-					],
-					term: $termStore
-				});
-				console.log(plans);
-			} else {
-				let courseIndex = activePlan.courses.findIndex(
-					(c: { course: string; sections: { section: string; selected: boolean }[] }) =>
-						c.course === course
-				);
-				console.log(courseIndex);
-				activePlan.courses[courseIndex].sections.forEach(
-					(s: { selected: boolean }) => (s.selected = false)
-				);
-				let sectionIndex = activePlan.courses[courseIndex].sections.findIndex(
-					(s: string) => s === section
-				);
-				console.log(sectionIndex);
-				activePlan.courses[courseIndex].sections[sectionIndex].selected = true;
-			}
-			return plans;
-		});
-	}
+	
 	async function onSelection(event: CustomEvent<AutocompleteOption<string>>): Promise<void> {
 		const sections = event.detail.meta;
 		const course = event.detail.value;
@@ -90,7 +56,7 @@
 			if (!activePlan) {
 				plans.push({
 					active: true,
-					courses: [{ course: course, sections: sections }],
+					courses: [{ course: course, selectedSection: '', sections: sections }],
 					term: $termStore,
 					id: uuidv4(),
 					name: `Plan ${plans.length + 1}`
@@ -104,7 +70,7 @@
 						(c: { course: string }) => c.course !== course
 					);
 				}
-				activePlan.courses.push({ course: course, sections: sections });
+				activePlan.courses.push({ course: course, selectedSection: '', sections: sections });
 			}
 			return plans;
 		});
@@ -153,20 +119,21 @@
 	{@const activePlan = $planStore.find((p) => p.active)}
 	{#if activePlan}
 		<Accordion>
-			{#each activePlan.courses as course}
+			{#each activePlan.courses as course, i}
 				<AccordionItem>
 					<svelte:fragment slot="summary">
 						{course.course}
 					</svelte:fragment>
 					<svelte:fragment slot="content">
-						{#each course.sections as section}
+						{#each course.sections as section, j}
 							<label class="flex items-center space-x-2">
 								<input
 									class="radio"
 									type="radio"
 									name="radio-{section.COURSE}"
 									value={section.SECTION}
-									on:change={() => selectSection(course.course, section)}
+									bind:group={$planStore[$planStore.findIndex((p) => p.active)].courses[i]
+										.selectedSection}
 								/>
 								<span>{section.COURSE}-{section.SECTION}, {section.INSTRUCTOR ?? 'TBA'}</span>
 							</label>


### PR DESCRIPTION
# Make state of section selection radio persist

Previously, when a radio input was selected and then the accordion was closed or the page was refreshed, the selection would be lost. This should fix that. The code is also a lot cleaner. 


![image](https://github.com/SIG-Frontline/ScheduleBuilder-Frontend/assets/77933963/7cb78a1f-a59f-41d9-9491-4c8ea1ed08db)
