### PR TITLE
[fix] CRN list formatting

### DIFF
--- a/src/components/Nav/Tabs/Tab_Insights/Tab_Insights.tsx
+++ b/src/components/Nav/Tabs/Tab_Insights/Tab_Insights.tsx
@@ -200,8 +200,8 @@ const Tab_Insights = () => {
                 return (
                   <div key={i}>
                     <List.Item>
-                      {i === 0 ? "" : ", "}
                       {crn}
+                      {i === cur_plan_crn_list.length - 1 ? "" : ", "}
                     </List.Item>
                     <br />
                   </div>


### PR DESCRIPTION
A simple fix for the CRN list formatting under the "Insights" tab.

Before:
![image](https://github.com/user-attachments/assets/78c73c1f-a102-4557-ae2a-351eb8bca33f)

After:
![image](https://github.com/user-attachments/assets/868b5536-7d02-4d1a-9fda-7c364da3f085)
