### PR TITLE
Feat name validation

### DIFF
--- a/src/components/Nav/Tabs/Tab_Plans/Plans/NewPlanButton.tsx
+++ b/src/components/Nav/Tabs/Tab_Plans/Plans/NewPlanButton.tsx
@@ -39,7 +39,7 @@ const NewPlanButton = () => {
       "Plan Name": (value) =>
         ValidatePlanName(value)
           ? null
-          : "Enter a valid plan name. Minimum: 1 character. Maximum 20 characters.",
+          : "Enter a valid plan name. Minimum: 1 character. Maximum: 20 characters.",
       "Plan Term": (value) => (value ? null : "Please select a term"),
     },
   });


### PR DESCRIPTION
**Description** 
Created a Regex that prevents users (NJIT students) from creating a plan with a name with any limitation. Thanks to regex alphanumeric characters, hyphens, and underscores are allow while emojis and special characters are not. 

**NewPlanButtom.tsx**

- Regex integrated. 

- Changed the length check for a Regex Validation called ValidateNamePlan. 
- Changed error message to "Enter a valid plan name" (Removing 4 characters minimum) 
![image](https://github.com/user-attachments/assets/e119cb1e-8568-404a-9738-5063236ebcd8)
![image](https://github.com/user-attachments/assets/4820a753-5b88-486c-87fc-6fba09f5578f)


**Testing steps**
I tested by creating every plan with the plan names I was given to to test it. It worked as I expected it.

The implementation performs correctly with the 'Dev' branch. Open to any suggestions. 😊