### PR TITLE
Bug disable search

### DIFF
--- a/src/components/Nav/Search/Search.tsx
+++ b/src/components/Nav/Search/Search.tsx
@@ -74,7 +74,7 @@ export default function Search({
   // state to track if enter has been pressed once, resulting in auto completed class title
   const [autoCompletedText, setAutoCompletedText] = useState(false);
   const [textHovered, setTextHovered] = useState(-1);
-  const [searchInputPlaceholder, setSearchInputPlaceholder] = useState("Search for a course");
+  const [searchInputPlaceholder, setSearchInputPlaceholder] = useState<string>("Search for a course");
   const scrollAreaRef = createRef<HTMLDivElement>();
 
   useEffect(() => {


### PR DESCRIPTION
**Description**
There was an undesired behavior where users could access the search bar and perform searches without having a plan selected. This resulted in a confusing experience where clicking on a course did nothing. ~~To address this, the search bar now becomes disabled if the user clicks on it without a selected plan, and a notification is displayed prompting them to create one. I think this is better than having the search bar disabled by default because it provides immediate feedback, making the experience feel more responsive rather than restricting the user upfront without context.~~

**Changes Made**
- New useeffect: Re-enables the search bar whenever there is a selectedPlanuuid
~~- handleInputClick: An onclick function that disables the search bar and shows a notification prompting the user to create a plan if there is no selectedPlanuuid~~