### PR TITLE
[fix] Incorrect Section Time

### DIFF
--- a/src/lib/client/processDate.ts
+++ b/src/lib/client/processDate.ts
@@ -7,6 +7,7 @@ export default function convertTime(
         hour: "2-digit",
         minute: "2-digit",
         hour12: true,
+		timeZone: 'UTC'
     });
 
     return h12 ? formattedTime.replace(/ AM| PM/, "") : formattedTime;


### PR DESCRIPTION
**Description**
A fix for the incorrect times being shown for the sections. This is due to a timezone conversion error. 

Before:
![image](https://github.com/user-attachments/assets/e5d6ab1e-d3e6-4ed8-b0a7-a171aac77bbb)

After:
![image](https://github.com/user-attachments/assets/e670cad2-901e-45a3-9f32-2ed2931e5227)
