### PR TITLE
Plan title error

### DIFF
--- a/src/components/Nav/Tabs/Tab_Plans/Plans/NewPlanButton.tsx
+++ b/src/components/Nav/Tabs/Tab_Plans/Plans/NewPlanButton.tsx
@@ -16,7 +16,7 @@ import { prettyTermText } from "@/lib/client/prettyTermText";
 
 const ValidatePlanName = (name: string): boolean => {
   const regexName = /^[a-zA-Z0-9-_\s]{1,20}$/;
-  return regexName.test(name);
+  return regexName.test(name) && name.trim().length > 0;
 } 
 
 const NewPlanButton = () => {


### PR DESCRIPTION
**Description**
A fix for a bug created when creating the Regex for allowing certain Plan Names. 

**Changes Made**
**-NewPlanButton.tsx**

- Modified Regex. adding "\s" in the Regex allowing plan names with spaces.
<img width="431" alt="image" src="https://github.com/user-attachments/assets/fba46a9a-d450-470e-b076-2ea626e4f16a" />

- Changed Error Alert to "Must be 1–20 characters. Letters, numbers, spaces, hyphens, and underscores only."
<img width="692" alt="image" src="https://github.com/user-attachments/assets/cd3d2477-445d-41ca-bf3e-800055426405" />

**Testing Steps**
I tested it by running it and checking if it accepts Plan Names with spaces in between. It worked as I expected it.

The implementation performs correctly with the 'Dev' branch. Open to any suggestions. 😊