### PR TITLE
[fix] Calendar Event Text Overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,3 +45,7 @@ body {
 .fc .fc-timegrid-col.fc-day-today {
   background-color: unset;
 }
+
+.fc-event-main {
+	overflow: hidden;
+}


### PR DESCRIPTION
**Description**
This PR fixes the bug where the text within the calendar events overflows and is visible, especially when viewed from dark mode.
Closes #170 

**Changes Made**
- Added a CSS attribute to prevent the text from overflowing

Before:
![image](https://github.com/user-attachments/assets/eb251715-7d3b-4fcf-bc2c-40332c8ccc96)

After:
![image](https://github.com/user-attachments/assets/2731972d-6f85-48b6-972b-4eacb50d5fa7)