### PR TITLE
[bug] course names overflowing in section list

### DIFF
--- a/src/components/Nav/Tabs/Tab_Plans/Plans/SectionSelection.tsx
+++ b/src/components/Nav/Tabs/Tab_Plans/Plans/SectionSelection.tsx
@@ -112,7 +112,7 @@ const SectionSelection = ({
               fw={500}
               ta={"center"}
               mx={"auto"}
-              className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+              className="overflow-ellipsis"
             >
               {courseTitle}
             </Title>


### PR DESCRIPTION
Courses such as "ENG SEM: GRAPHIC NOVELS, COMICS AND CARTOONS" were overflowing causing horizontal scrolling on the page

Changed overflow properties for course title in SectionsSelection.tsx