### PR TITLE
change search result highlight color based on color scheme

### DIFF
--- a/src/components/Nav/Search/Search.tsx
+++ b/src/components/Nav/Search/Search.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine/hooks';
 import { subjectStore } from '@/lib/client/subjectStore';
 import { filterStore } from '@/lib/client/filterStore';
+import { useComputedColorScheme } from '@mantine/core';
 // the below subjects are stored in the database as just one subject and no code - so when the subject is selected, just add the course to the plan
 const specialSubjects = [
   'FYSSEM',
@@ -43,6 +44,9 @@ export default function Search({
   onFocused: () => void;
   onBlurred: () => void;
 }) {
+  const computedColorScheme = useComputedColorScheme();
+  const highLightColor = computedColorScheme === 'dark' ? '#1A71C2' : '#000000';
+
   const ref = useClickOutside(() => {
     onBlurred();
   });
@@ -400,6 +404,7 @@ export default function Search({
                     )}
                     highlightStyles={{
                       fontWeight: 700,
+                      color: highLightColor,
                       backgroundColor: 'rgba(255, 255, 255, 0)', // need to set a bg color but opacity 0 removes the bg
                     }}
                   >
@@ -433,6 +438,7 @@ export default function Search({
                     highlight={extractMatchingText(option, textBoxValue)}
                     highlightStyles={{
                       fontWeight: 700,
+                      color: highLightColor,
                       backgroundColor: 'rgba(255, 255, 255, 0)', // need to set a bg color but opacity 0 removes the bg
                     }}
                   >


### PR DESCRIPTION
When dark mode is selected, the highlight color of the search result will now be a dark blue, making it stand out against the dark background. 

Light mode remains the same.

# Before:

<img width="355" height="240" alt="image" src="https://github.com/user-attachments/assets/bc8feb9f-0fa1-43bd-a32f-a0fa688c9823" />
<img width="352" height="240" alt="image" src="https://github.com/user-attachments/assets/ab62c43a-7df7-4e71-8073-3ffa54a79499" />


# After: 
<img width="353" height="240" alt="image" src="https://github.com/user-attachments/assets/cbd994a7-1446-4b0c-ab80-8a9f06d828ad" />
<img width="355" height="240" alt="image" src="https://github.com/user-attachments/assets/76fadd1a-a196-42ed-bce1-687d7743761f" />

