### PR TITLE
[feat] Organizer Cycling

### DIFF
--- a/src/lib/client/bestPlansStore.ts
+++ b/src/lib/client/bestPlansStore.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { Plan } from "./planStore";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+// A session-store cache to store the 5 top plans the organizer 
+interface BestPlansStoreState {
+  plans: Plan[];
+  index: number;
+  setPlans: (plans: Plan[]) => void;
+  getNext: () => Plan;
+  getIndex: () => number;
+  getSize: () => number;
+}
+
+export const bestPlansStore = create<BestPlansStoreState>()(
+  persist(
+    (set, get) => ({
+      plans: [],
+      index: 0,
+      setPlans(plans) {
+        set({ plans: plans, index: 0 });
+      },
+      getNext() {
+        const { plans } = get();
+        let { index } = get();
+
+        index++;
+        if (index >= plans.length) index = 0;
+
+        console.log(index);
+
+        set({ index: index });
+        return plans[index];
+      },
+      getIndex() {
+        const { index } = get();
+        return index;
+      },
+      getSize() {
+        const { plans } = get();
+        return plans.length;
+      },
+    }),
+    {
+      name: "best-plans-store",
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);

--- a/src/lib/server/actions/getOrganizedPlan.ts
+++ b/src/lib/server/actions/getOrganizedPlan.ts
@@ -10,7 +10,7 @@ import { Plan } from '@/lib/client/planStore';
  */
 export async function organizePlan(
   currentPlan: Plan
-): Promise<Plan | { error: string }> {
+): Promise<Plan[] | { error: string }> {
   if (!currentPlan)
     return {
       error: "No plan provided!",


### PR DESCRIPTION
**Description**
This PR introduces a session cache that stores the top 5 'best' schedules generated by the organizer, which can be cycled through with repeated clicks of the 'Find Best Schedule' button.

<img width="351" height="67" alt="image" src="https://github.com/user-attachments/assets/aba7523c-322b-4e80-8eb2-ee5ad29f4db2" />

> [!note]
> This PR should be merged with [ScheduleBuilder-core#29](https://github.com/SIG-Frontline/ScheduleBuilder-core/pull/29), which provides the backend support for this

**Changes Made**

- Created the `bestPlanStore` cache to store the best plans
- Hashes the user's plan and settings to detect any changes, and to re-run the organizer
- Updated the 'Find Best Schedule' button to display the current plan 

**Testing**
Manual testing was done to ensure the results were correct on the frontend.