### PR TITLE
Bug course titles

### DIFF
--- a/src/components/Cal_Grid/Cal_Grid.tsx
+++ b/src/components/Cal_Grid/Cal_Grid.tsx
@@ -60,7 +60,7 @@ const Cal_Grid = () => {
         return {
           title: `${courseCode} - ${section.sectionNumber}`,
           extendedProps: {
-            title: courseTitle,
+            title: section.title !== undefined ? section.title : courseTitle,
             crn: section.crn,
             instructor: section.instructor,
             location: meetingTime.building + ' ' + meetingTime.room,

--- a/src/components/Nav/Tabs/Tab_Plans/Plans/CourseAccordion.tsx
+++ b/src/components/Nav/Tabs/Tab_Plans/Plans/CourseAccordion.tsx
@@ -24,6 +24,12 @@ const CourseAccordion = ({ course }: { course: Course }) => {
   const setOpenCourseId = plan_store.setOpenCourseId;
   const courseCode = course.code;
   const isOpen = openCourseId === course.code;
+  let hasUniqueTitle = false;
+  course.sections.map((section) => {
+    if (section.title !== course.title && section.title !== undefined) {
+      hasUniqueTitle = true;
+    }
+  });
   return (
     <>
       <Accordion
@@ -131,6 +137,7 @@ const CourseAccordion = ({ course }: { course: Course }) => {
               courseCode={courseCode}
               sections={course.sections}
               courseTitle={course.title}
+              hasUniqueTitle={hasUniqueTitle}
             />
           </Accordion.Panel>
         </Accordion.Item>

--- a/src/components/Nav/Tabs/Tab_Plans/Plans/SectionSelection.tsx
+++ b/src/components/Nav/Tabs/Tab_Plans/Plans/SectionSelection.tsx
@@ -16,10 +16,12 @@ const SectionSelection = ({
   courseCode,
   sections,
   courseTitle,
+  hasUniqueTitle,
 }: {
   courseCode: string;
   sections: Section[];
   courseTitle: string;
+  hasUniqueTitle: boolean;
 }) => {
   // const matches = useMediaQuery(
   //   "only screen and (orientation: landscape) and (min-width: 1201px)"
@@ -50,7 +52,9 @@ const SectionSelection = ({
       <Stack gap={0} align="flex-start">
         <Group align="start" w={'100%'} mt={3}>
           <Text size="md" fw={600}>
-            {courseCode}-{item.sectionNumber}
+            {hasUniqueTitle
+              ? item.sectionNumber + '-' + item.title
+              : courseCode + '-' + item.sectionNumber}
           </Text>
           {item.meetingTimes.length > 0 && (
             <Badge variant="light" ms={'auto'}>
@@ -105,6 +109,7 @@ const SectionSelection = ({
     <>
       <Group justify="start" align="start" mt={'sm'}>
         <div className="flex-grow">
+          {!hasUniqueTitle &&           
           <Group mb={'sm'} pos={'relative'}>
             <Title
               order={3}
@@ -116,7 +121,7 @@ const SectionSelection = ({
             >
               {courseTitle}
             </Title>
-          </Group>
+          </Group>}
 
           <Radio.Group
             value={value}

--- a/src/components/Nav/Tabs/Tab_Plans/Plans/SectionSelection.tsx
+++ b/src/components/Nav/Tabs/Tab_Plans/Plans/SectionSelection.tsx
@@ -42,11 +42,19 @@ const SectionSelection = ({
       <Group gap="sm" align="start">
         <Radio.Indicator className="hover:cursor-pointer" />
         <Group gap={2} align="start" ms={'auto'}>
-          {item.meetingTimes.map((time) => (
-            <Badge variant="light" key={time.day + time.startTime}>
-              {time.day}
+          <Badge variant='light'>
+            {item.meetingTimes.map((time) => (
+                <>{time.day} </>
+            ))}
+          </Badge>
+          {item.meetingTimes.length > 0 && (
+            <Badge variant="light" ms={'auto'}>
+              <Text size="xs" c="blue">
+                {convertTime(item.meetingTimes[0].startTime)} -{' '}
+                {convertTime(item.meetingTimes[0].endTime, false)}
+              </Text>
             </Badge>
-          ))}
+          )}
         </Group>
       </Group>
       <Stack gap={0} align="flex-start">
@@ -56,14 +64,6 @@ const SectionSelection = ({
               ? item.sectionNumber + '-' + item.title
               : courseCode + '-' + item.sectionNumber}
           </Text>
-          {item.meetingTimes.length > 0 && (
-            <Badge variant="light" ms={'auto'}>
-              <Text size="xs" c="blue">
-                {convertTime(item.meetingTimes[0].startTime)} -{' '}
-                {convertTime(item.meetingTimes[0].endTime, false)}
-              </Text>
-            </Badge>
-          )}
         </Group>
 
         <Text size="sm" c="dimmed">

--- a/src/lib/client/planStore.ts
+++ b/src/lib/client/planStore.ts
@@ -36,6 +36,7 @@ export type Course = {
 
 export type Section = {
   meetingTimes: MeetingTime[];
+  title: string;
   instructor: string;
   crn: string;
   currentEnrollment: number;
@@ -319,7 +320,7 @@ export const planStore = create<PlanStoreState>()(
           commuteTimeHours:
             (settings as Partial<organizerSettings>).commuteTimeHours ??
             defaultSettings.commuteTimeHours,
-          daysOnCampus:
+          daysOnCampus: 
             settings.daysOnCampus ?? defaultSettings.daysOnCampus,
           compactPlan: settings.compactPlan ?? defaultSettings.compactPlan,
           eventPriority:

--- a/src/lib/client/planStore.ts
+++ b/src/lib/client/planStore.ts
@@ -320,8 +320,7 @@ export const planStore = create<PlanStoreState>()(
           commuteTimeHours:
             (settings as Partial<organizerSettings>).commuteTimeHours ??
             defaultSettings.commuteTimeHours,
-          daysOnCampus: 
-            settings.daysOnCampus ?? defaultSettings.daysOnCampus,
+          daysOnCampus: settings.daysOnCampus ?? defaultSettings.daysOnCampus,
           compactPlan: settings.compactPlan ?? defaultSettings.compactPlan,
           eventPriority:
             settings.eventPriority ?? defaultSettings.eventPriority,

--- a/src/lib/server/actions/getSectionData.ts
+++ b/src/lib/server/actions/getSectionData.ts
@@ -43,6 +43,7 @@ export async function getSectionData(
 
     // Format sections
     course.sections = course.sections.map((section: SectionDocument) => ({
+      title: section.TITLE ?? '',
       instructor: section.INSTRUCTOR ?? '',
       sectionNumber: section.SECTION ?? '',
       status: section.STATUS ?? 'Unknown',


### PR DESCRIPTION
Fixing [this issue](https://github.com/SIG-Frontline/ScheduleBuilder/issues/193)

When multiple sections of a course use the same course code but have different titles (i.e. HS404 or CS485), they are indistinguishable in ScheduleBuilder.

---

### `src/lib/server/actions/getSectionData.ts`
- Will now store section title in each section
### `src/lib/client/planStore.ts`
- Add "title" to section object

---

Since the change to getSectionData cannot be done retroactively for all users, checks have been added to account for trying to grab `section.title` when no value exists.
When we might want to display `section.title`, it is always checked that it is not undefined, and if it is undefined, default back to courseTitle. With that in mind, in order to see these changes, you must create a new plan.

<img width="2974" height="1978" alt="image" src="https://github.com/user-attachments/assets/10b23aaa-61a8-4892-94f0-ff062e7ee235" />
